### PR TITLE
Fix bootstrapping MSYS2 pacman (#11499)

### DIFF
--- a/scripts/cmake/vcpkg_acquire_msys.cmake
+++ b/scripts/cmake/vcpkg_acquire_msys.cmake
@@ -98,6 +98,18 @@ function(vcpkg_acquire_msys PATH_TO_ROOT_OUT)
       COMMAND ${PATH_TO_ROOT}/usr/bin/bash.exe --noprofile --norc -c "PATH=/usr/bin;gpgconf --homedir /etc/pacman.d/gnupg --kill all"
       WORKING_DIRECTORY ${TOOLPATH}
     )
+    # we need to update pacman before anything else due to pacman transitioning
+    # to using zstd packages, and our pacman is too old to support those
+    _execute_process(
+      COMMAND ${PATH_TO_ROOT}/usr/bin/bash.exe --noprofile --norc -c "PATH=/usr/bin;pacman -Sy pacman --noconfirm"
+      WORKING_DIRECTORY ${TOOLPATH}
+    )
+    # dash relies on specific versions of the base packages, which prevents us
+    # from doing a proper update. However, we don't need it so we remove it
+    _execute_process(
+      COMMAND ${PATH_TO_ROOT}/usr/bin/bash.exe --noprofile --norc -c "PATH=/usr/bin;pacman -Rc dash --noconfirm"
+      WORKING_DIRECTORY ${TOOLPATH}
+    )
     _execute_process(
       COMMAND ${PATH_TO_ROOT}/usr/bin/bash.exe --noprofile --norc -c "PATH=/usr/bin;pacman -Syu --noconfirm"
       WORKING_DIRECTORY ${TOOLPATH}


### PR DESCRIPTION
MSYS2 pacman recently transitioned to using .zstd packages from .xz packages, but we bootstrap from a pacman that doesn't support those. We need to add some additional bootstrap steps before pacman works.

**Describe the pull request**

- What does your PR fix? Fixes #11499

- Which triplets are supported/not supported? Have you updated the CI baseline? These changes shouldn't affect different triplets since it uses an internal msys2 tree.

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)? To the best of my knowledge yes.
